### PR TITLE
Prevent duplicate relationships when adding multiple entries in the Dashboard

### DIFF
--- a/src/CloudShapes.Dashboard/Components/RelationshipEditorModal/RelationshipEditorModal.razor
+++ b/src/CloudShapes.Dashboard/Components/RelationshipEditorModal/RelationshipEditorModal.razor
@@ -187,6 +187,7 @@
         if (string.IsNullOrWhiteSpace(relationship.Path)) validationErrors.Add("<b>Path</b> must be set");
         if (validationErrors.Count > 0) return;
         if (OnCreate.HasDelegate) await OnCreate.InvokeAsync(relationship);
+        Relationship = new();
     }
 
 }


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Ensure that RelationshipEditorModal resets its state with a new instance of ProjectionRelationshipDefinition after a relationship is created. This prevents previously entered relationships from being overwritten and ensures each added relationship is stored correctly.

Closes #24

**Special notes for reviewers**:

**Additional information (if needed):**