### PR TITLE
Fix `decimal` BSON deserialization

### DIFF
--- a/src/CloudShapes.Application/Commands/CloudEvents/IngestCloudEventCommandHandler.cs
+++ b/src/CloudShapes.Application/Commands/CloudEvents/IngestCloudEventCommandHandler.cs
@@ -122,7 +122,7 @@ public class IngestCloudEventCommandHandler(ILogger<IngestCloudEventCommandHandl
         ArgumentNullException.ThrowIfNull(e);
         ArgumentException.ThrowIfNullOrWhiteSpace(correlationId);
         var projection = (await ExpressionEvaluator.EvaluateAsync(trigger.State, e, cancellationToken: cancellationToken).ConfigureAwait(false))!;
-        var document = BsonDocument.Create(projection);
+        var document = JsonSerializer.SerializeToBsonDocument(projection)!;
         document["_id"] = correlationId;
         await DbContext.Set(projectionType).AddAsync(document, cancellationToken).ConfigureAwait(false);
     }
@@ -161,7 +161,7 @@ public class IngestCloudEventCommandHandler(ILogger<IngestCloudEventCommandHandl
                 object updated;
                 if (trigger.State is string expression) updated = (await ExpressionEvaluator.EvaluateAsync(expression, e, arguments, cancellationToken: cancellationToken).ConfigureAwait(false))!;
                 else updated = (await ExpressionEvaluator.EvaluateAsync(trigger.State!, e, arguments, cancellationToken: cancellationToken).ConfigureAwait(false))!;
-                projection = BsonDocument.Create(updated);
+                projection = JsonSerializer.SerializeToBsonDocument(updated)!;
                 projection["_id"] = correlationId;
                 projection[DocumentMetadata.PropertyName] = metadata;
                 await projections.UpdateAsync(projection, cancellationToken).ConfigureAwait(false);

--- a/src/CloudShapes.Application/Extensions/IJsonSerializerExtensions.cs
+++ b/src/CloudShapes.Application/Extensions/IJsonSerializerExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright © 2025-Present The Cloud Shapes Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CloudShapes.Application;
+
+/// <summary>
+/// Defines extensions for <see cref="IJsonSerializer"/>s
+/// </summary>
+public static class IJsonSerializerExtensions
+{
+
+    /// <summary>
+    /// Serializes the specified value as a <see cref="BsonDocument"/>
+    /// </summary>
+    /// <param name="serializer">The extended <see cref="IJsonSerializer"/></param>
+    /// <param name="graph">The value to serialize</param>
+    /// <returns>The deserialized <see cref="BsonDocument"/></returns>
+    public static BsonDocument? SerializeToBsonDocument(this IJsonSerializer serializer, object? graph)
+    {
+        if (graph == null) return null;
+        var json = serializer.SerializeToText(graph);
+        return BsonDocument.Parse(json);
+    }
+
+}

--- a/src/CloudShapes.Application/Extensions/QueryOptionsExtensions.cs
+++ b/src/CloudShapes.Application/Extensions/QueryOptionsExtensions.cs
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using CloudShapes.Integration.Models;
-
 namespace CloudShapes.Application;
 
 /// <summary>

--- a/src/CloudShapes.Application/Services/Repository.cs
+++ b/src/CloudShapes.Application/Services/Repository.cs
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using MongoDB.Bson.Serialization.Serializers;
-
 namespace CloudShapes.Application.Services;
 
 /// <summary>
@@ -297,9 +295,7 @@ public class Repository
         var patchHandler = PatchHandlers.FirstOrDefault(h => h.Supports(patch.Type)) ?? throw new ProblemDetailsException(new(Problems.Types.UnsupportedPatchType, Problems.Titles.UnsupportedPatchType, Problems.Statuses.Unprocessable, StringFormatter.Format(Problems.Details.UnsupportedPatchType, patch.Type)));
         var patchDocument = await ExpressionEvaluator.EvaluateAsync(patch.Document, new { }, arguments, cancellationToken: cancellationToken).ConfigureAwait(false);
         projectionState = await patchHandler.ApplyPatchAsync(patch.Document, projectionState, cancellationToken).ConfigureAwait(false);
-        var json = JsonSerializer.SerializeToText(projectionState);
-        var patchedProjection = BsonDocument.Parse(json);
-        return await UpdateAsync(patchedProjection, cancellationToken).ConfigureAwait(false);
+        return await UpdateAsync(JsonSerializer.SerializeToBsonDocument(projectionState)!, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>

--- a/src/CloudShapes.Data/Serialization/Bson/DecimalBsonSerializer.cs
+++ b/src/CloudShapes.Data/Serialization/Bson/DecimalBsonSerializer.cs
@@ -1,0 +1,32 @@
+﻿// Copyright © 2025-Present The Cloud Shapes Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace CloudShapes.Data.Serialization.Bson;
+
+/// <summary>
+/// Represents the <see cref="SerializerBase{TValue}"/> used to serialize/deserialize <see cref="decimal"/>s to/from BSON
+/// </summary>
+public class DecimalBsonSerializer
+    : SerializerBase<decimal>
+{
+
+    /// <inheritdoc/>
+    public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, decimal value) => context.Writer.WriteDouble((double)value);
+
+    /// <inheritdoc/>
+    public override decimal Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args) => (decimal)context.Reader.ReadDouble();
+
+}


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Replaces all calls to `BsonDocument.Create` by calls to `JsonSerializer.SerializeToBsonDocument`, thus solving issues with `decimals` being serialized as `Decimal128`