### PR TITLE
Fix the `ProjectionApiClient.PatchAsync` method by replacing its `UpdateProjectionCommand` argument by `PatchProjectionCommand`

### DIFF
--- a/src/CloudShapes.Api.Client/Services/Interfaces/IProjectionsApiClient.cs
+++ b/src/CloudShapes.Api.Client/Services/Interfaces/IProjectionsApiClient.cs
@@ -61,7 +61,7 @@ public interface IProjectionsApiClient
     /// <param name="command">The command to execute</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
     /// <returns>The newly created projection</returns>
-    Task<object> PatchAsync(UpdateProjectionCommand command, CancellationToken cancellationToken = default);
+    Task<object> PatchAsync(PatchProjectionCommand command, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes the specified projection

--- a/src/CloudShapes.Api.Client/Services/ProjectionsApiClient.cs
+++ b/src/CloudShapes.Api.Client/Services/ProjectionsApiClient.cs
@@ -81,7 +81,7 @@ public class ProjectionsApiClient(ILogger<ProjectionsApiClient> logger, IJsonSer
     }
 
     /// <inheritdoc/>
-    public virtual async Task<object> PatchAsync(UpdateProjectionCommand command, CancellationToken cancellationToken = default)
+    public virtual async Task<object> PatchAsync(PatchProjectionCommand command, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(command);
         var json = JsonSerializer.SerializeToText(command);


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the `ProjectionApiClient.PatchAsync` method by replacing its `UpdateProjectionCommand` argument by `PatchProjectionCommand`